### PR TITLE
Fix: Preserve numeric conversion accuracy in `ColorSliderTextFieldConfiguration`

### DIFF
--- a/Sources/ColorPicker/Feature/SliderColorPicker/ColorSliderTextField.swift
+++ b/Sources/ColorPicker/Feature/SliderColorPicker/ColorSliderTextField.swift
@@ -11,25 +11,28 @@ extension ColorSliderTextFieldConfiguration {
             (Double(text) ?? 0) / 255.0
         },
         valueToText: { value in
-            "\(Int(value * 255.0))"
+            let v = (value * 255.0).rounded()
+            return "\(max(0, min(255, Int(v))))"
         }
     )
-    
+
     static var radius: Self = .init(
         textToValue: { text in
             (Double(text) ?? 0) / 360.0
         },
         valueToText: { value in
-            "\(Int(value * 360.0))"
+            let v = (value * 360.0).rounded()
+            return "\(max(0, min(360, Int(v))))"
         }
     )
-    
+
     static var percent: Self = .init(
         textToValue: { text in
             (Double(text) ?? 0) / 100.0
         },
         valueToText: { value in
-            "\(Int(value * 100.0))"
+            let v = (value * 100.0).rounded()
+            return "\(max(0, min(100, Int(v))))"
         }
     )
 }


### PR DESCRIPTION
Hey @noppefoxwolf 👋

Thank you so much for your awesome ColorPicker library 🙏

I'm encountering an issue (https://github.com/isontheline/pro.webssh.net/issues/1412) where user can't put some RGB values.

Do you think you can apply this PR on your main branch?
Have you a better way to fix it?

Have a great day ☀️

===========

## Problem  
When converting text input back and forth between `String` ↔︎ `Double` ↔︎ `String`, floating-point precision errors caused off-by-one truncations.  
Example:  

- User enters `96` (percent mode)  
- Internal value becomes `0.96`  
- Converting back with `Int(value * 100)` yields `95.9999…` → truncated to `95`  

This resulted in unexpected value loss.

## Solution  
Applied rounding before casting to `Int` inside all `valueToText` closures (`hex`, `radius`, `percent`):  

```swift
let v = (value * scale).rounded()
return "\(Int(v))"
```

Additionally, values are clamped to the valid ranges (`0...255`, `0...360`, `0...100`) to avoid accidental out-of-range results.

## Impact  
- Fixes off-by-one conversion errors (e.g., `96` remains `96`)  
- Improves reliability and user trust in the text-to-slider synchronization  
- No breaking changes to API  

## Testing  
- Verified with values that previously failed (e.g., 96, 255, 360, 100).  
- Round-trip conversion now returns the original value consistently.  
